### PR TITLE
lintsOnChange parameter missed in v2 upgrade

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -75,7 +75,7 @@ export default {
             name: 'PHPStan',
             grammarScopes: ['text.html.php', 'source.php'],
             scope: 'file',
-            lintOnFly: false,
+            lintsOnChange: false,
             lint: async (textEditor) => {
                 const filePath = textEditor.getPath();
                 const fileText = textEditor.getText();


### PR DESCRIPTION
The `lintOnFly` parameter was renamed to `lintsOnChange` in the v2 API, but this change was missed in #5.