### PR TITLE
Suppress the unfixable errors caused by simultaneous PHPSTAN processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A debug mode option to produce more verbose error output.
+  - Related to the fix for #9 to provide a way to debug calls to phpstan.
 ### Fixed
 - Fix for #9: Best fix we'll get without massive changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix for #9: Best fix we'll get without massive changes.
 
 ## [v2.1.1] - 2019-12-08
 ### Fixed

--- a/lib/main.js
+++ b/lib/main.js
@@ -60,6 +60,9 @@ export default {
             }),
             atom.config.observe('atom-linter-phpstan.memoryLimit', (value) => {
                 this.memoryLimit = value;
+            }),
+            atom.config.observe('atom-linter-phpstan.enableDebugMode', (value) => {
+                this.isDebugModeEnabled = value;
             })
         );
     },
@@ -163,8 +166,9 @@ export default {
 
                 // PHPStan exec options
                 const execOptions = {
+                    cwd: workDir,
                     timeout: 1000 * 60 * 2, // ms * s * m: 5 minutes
-                    throwOnStderr: false,
+                    throwOnStderr: !this.isDebugModeEnabled,
                     ignoreExitCode: true
                 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -163,9 +163,9 @@ export default {
 
                 // PHPStan exec options
                 const execOptions = {
-                    cwd: workDir,
-                    ignoreExitCode: true,
-                    timeout: 1000 * 60 * 5, // ms * s * m: 5 minutes
+                    timeout: 1000 * 60 * 2, // ms * s * m: 5 minutes
+                    throwOnStderr: false,
+                    ignoreExitCode: true
                 };
 
                 // Execute PHPStan

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,129 @@
+{
+  "name": "atom-linter-phpstan",
+  "version": "2.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "atom-linter": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/atom-linter/-/atom-linter-10.0.0.tgz",
+      "integrity": "sha1-0nu3Tl+PCKdKQL6ynuGlDZdUPIk=",
+      "requires": {
+        "named-js-regexp": "^1.3.1",
+        "sb-exec": "^4.0.0",
+        "sb-promisify": "^2.0.1",
+        "tmp": "~0.0.28"
+      }
+    },
+    "atom-package-deps": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-4.6.2.tgz",
+      "integrity": "sha512-GOcCULZPzpcFfnHo9Oz5fT/EaArFHNs84E4rp/Nox0/GlS1UYkEF44FRdgD+7TxAudRfQAXE0a8wh0GealCXZg==",
+      "requires": {
+        "atom-package-path": "^1.1.0",
+        "sb-fs": "^3.0.0",
+        "semver": "^5.3.0"
+      }
+    },
+    "atom-package-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/atom-package-path/-/atom-package-path-1.1.0.tgz",
+      "integrity": "sha1-tR/tvADnyM5SI9DYA9t6P09pYU8=",
+      "requires": {
+        "sb-callsite": "^1.1.2"
+      }
+    },
+    "consistent-env": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
+      "integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
+      "requires": {
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "named-js-regexp": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/named-js-regexp/-/named-js-regexp-1.3.5.tgz",
+      "integrity": "sha512-XO0DPujDP9IWpkt690iWLreKztb/VB811DGl5N3z7BfhkMJuiVZXOi6YN/fEB9qkvtMVTgSZDW8pzdVt8vj/FA=="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "sb-callsite": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sb-callsite/-/sb-callsite-1.1.2.tgz",
+      "integrity": "sha1-KBkftm1k46PukghKlakPy1ECJDs="
+    },
+    "sb-exec": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-4.0.0.tgz",
+      "integrity": "sha1-RnR/DfFiYmwW6/D+pCJFrRqoWco=",
+      "requires": {
+        "consistent-env": "^1.2.0",
+        "lodash.uniq": "^4.5.0",
+        "sb-npm-path": "^2.0.0"
+      }
+    },
+    "sb-fs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sb-fs/-/sb-fs-3.0.0.tgz",
+      "integrity": "sha1-+9zdMBDoChuOJ0kM7zNgZJdCA7g=",
+      "requires": {
+        "sb-promisify": "^2.0.1",
+        "strip-bom-buf": "^1.0.0"
+      }
+    },
+    "sb-memoize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sb-memoize/-/sb-memoize-1.0.2.tgz",
+      "integrity": "sha1-EoN1xi3bnMT/qQXQxaWXwZuurY4="
+    },
+    "sb-npm-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
+      "integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
+      "requires": {
+        "sb-memoize": "^1.0.2",
+        "sb-promisify": "^2.0.1"
+      }
+    },
+    "sb-promisify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sb-promisify/-/sb-promisify-2.0.2.tgz",
+      "integrity": "sha1-QnelR1RIiqlnXYhuNU24lMm9yYE="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "strip-bom-buf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "requires": {
+        "is-utf8": "^0.2.1"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,157 @@
 {
   "name": "atom-linter-phpstan",
   "version": "2.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "atom-linter": "^10.0.0",
+        "atom-package-deps": "^4.0.1"
+      },
+      "engines": {
+        "atom": ">=1.4.0 <2.0.0"
+      }
+    },
+    "node_modules/atom-linter": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/atom-linter/-/atom-linter-10.0.0.tgz",
+      "integrity": "sha1-0nu3Tl+PCKdKQL6ynuGlDZdUPIk=",
+      "dependencies": {
+        "named-js-regexp": "^1.3.1",
+        "sb-exec": "^4.0.0",
+        "sb-promisify": "^2.0.1",
+        "tmp": "~0.0.28"
+      }
+    },
+    "node_modules/atom-package-deps": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-4.6.2.tgz",
+      "integrity": "sha512-GOcCULZPzpcFfnHo9Oz5fT/EaArFHNs84E4rp/Nox0/GlS1UYkEF44FRdgD+7TxAudRfQAXE0a8wh0GealCXZg==",
+      "dependencies": {
+        "atom-package-path": "^1.1.0",
+        "sb-fs": "^3.0.0",
+        "semver": "^5.3.0"
+      }
+    },
+    "node_modules/atom-package-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/atom-package-path/-/atom-package-path-1.1.0.tgz",
+      "integrity": "sha1-tR/tvADnyM5SI9DYA9t6P09pYU8=",
+      "dependencies": {
+        "sb-callsite": "^1.1.2"
+      }
+    },
+    "node_modules/consistent-env": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
+      "integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
+      "dependencies": {
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "node_modules/named-js-regexp": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/named-js-regexp/-/named-js-regexp-1.3.5.tgz",
+      "integrity": "sha512-XO0DPujDP9IWpkt690iWLreKztb/VB811DGl5N3z7BfhkMJuiVZXOi6YN/fEB9qkvtMVTgSZDW8pzdVt8vj/FA=="
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sb-callsite": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sb-callsite/-/sb-callsite-1.1.2.tgz",
+      "integrity": "sha1-KBkftm1k46PukghKlakPy1ECJDs="
+    },
+    "node_modules/sb-exec": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-4.0.0.tgz",
+      "integrity": "sha1-RnR/DfFiYmwW6/D+pCJFrRqoWco=",
+      "dependencies": {
+        "consistent-env": "^1.2.0",
+        "lodash.uniq": "^4.5.0",
+        "sb-npm-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sb-fs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sb-fs/-/sb-fs-3.0.0.tgz",
+      "integrity": "sha1-+9zdMBDoChuOJ0kM7zNgZJdCA7g=",
+      "dependencies": {
+        "sb-promisify": "^2.0.1",
+        "strip-bom-buf": "^1.0.0"
+      }
+    },
+    "node_modules/sb-memoize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sb-memoize/-/sb-memoize-1.0.2.tgz",
+      "integrity": "sha1-EoN1xi3bnMT/qQXQxaWXwZuurY4="
+    },
+    "node_modules/sb-npm-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
+      "integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
+      "dependencies": {
+        "sb-memoize": "^1.0.2",
+        "sb-promisify": "^2.0.1"
+      }
+    },
+    "node_modules/sb-promisify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sb-promisify/-/sb-promisify-2.0.2.tgz",
+      "integrity": "sha1-QnelR1RIiqlnXYhuNU24lMm9yYE="
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/strip-bom-buf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "dependencies": {
+        "is-utf8": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    }
+  },
   "dependencies": {
     "atom-linter": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,12 @@
       "default": "100M",
       "description": "Memory limit for analysis",
       "order": 9
+    },
+    "enableDebugMode": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable the debug mode for this linter package.",
+      "order": 10
     }
   }
 }


### PR DESCRIPTION
So this PR should address #9 however it comes at the cost of suppressing all errors from PHPSTAN at CLI. So it won't be the best for debugging things, however it removes the errors that are naturally caused by how things work.

## Root Issue
Running PHPstan in multiple processes at one time can lead to false positives for PHP memory limits being hit. The way around this it to run a single process. When running PHPstan directly this isn't a concern since you tell it to go after the full project.

With linters we're just checking a single file and loading the autoloader. Further, because how Atom's linters work it's likely that it's scanning many files at once. All spawning their own children processes using [steelbrain/atom-linter](https://github.com/steelbrain/atom-linter) to spawn the linter processes.

## Other potential solutions:

### Patch PHPSTAN:
If it were possible to patch phpstan to be more accurate about the error being reported in this very odd edge case that could help. Then we could potentially catch and suppress only the false positives.

### Patch [steelbrain/exec](https://github.com/steelbrain/exec)
If we could execute a single process at a time it could help. The linter helper package just proxies exec to this package. So if this package had a locking single execution method that could resolve the issue. The huge con here would be things would be much slower.

### Patch locally to implement single process execution
I'm not familiar enough with Atom and haven't coded JS very heavily recently. So I don't really know how possible this is to pull off. I would assume not super easy, but likely possible.

I know nodejs has execSync to execute syncronisly. However I think the issue would be that Atom and the linter are still going to trigger atom-linter-phpstan async - thus allowing mutliple execSync to be running. Unless I'm wrong about that, which I could be, then it's not as simple as it may seem.