### PR TITLE
Temprory disabling output to standard error, as suggested PR#13

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -166,6 +166,7 @@ export default {
                     cwd: workDir,
                     ignoreExitCode: true,
                     timeout: 1000 * 60 * 5, // ms * s * m: 5 minutes
+                    throwOnStderr: false,
                 };
 
                 // Execute PHPStan


### PR DESCRIPTION
…hub.com/AtomLinter/atom-linter-phpstan/pull/13#issuecomment-784457165

Hi @mallardduck , regarding issue #9 and the provided temprory fix suggested [here](https://github.com/AtomLinter/atom-linter-phpstan/pull/13#issuecomment-784457165)

this pr will eliminate the error to linter output and make it work. (until complete fix)